### PR TITLE
A larger-than-I-had-planned refactoring

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,6 @@ LICENSE
 Dockerfile
 docker-compose.yml
 .gitignore
+.local
+venv/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.swp
+venv/
+.local/
+.idea/

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import aiohttp, configparser, discord, os, json, datetime
+from abc import ABC, abstractmethod
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 config_path = os.getenv('CONFIG_PATH', 'config.ini')
@@ -7,57 +8,43 @@ config = configparser.ConfigParser()
 config.read(config_path)
 
 streamer_api = config['twitch']['streamer_api']
-game_api     = config['twitch']['game_api']
-client_id    = config['twitch']['clientid']
-headers      = {'Client-ID': client_id}
+game_api = config['twitch']['game_api']
+client_id = config['twitch']['clientid']
+headers = {'Client-ID': client_id}
 
-class DiscordClient(discord.Client):
-    async def on_ready(self):
-        print(f"Logged in as {self.user}")
 
-class Streamer():
-    def __init__(self, streamer, frequency, message, channel):
-        self.streamer = streamer
-        self.went_live = 0
-        self.live_last_tick = False
-        self.message = message
-        self.channel = channel
-        self.job = sched.add_job(self.process_live_check, 'interval', seconds=10)#TESTING
-        self.embed = discord.Embed(title=f"https://twitch.tv/{self.streamer}", color=discord.Color(0x6441a4))
-        self.embed.set_footer(text="bot by Woovie#5555 | https://github.com/woovie/twitchlive")
-        self.embed.set_thumbnail(url="https://assets.help.twitch.tv/Glitch_Purple_RGB.png")
-    async def process_live_check(self):
-        if (live_data := await self.is_live()) is not None:
-            if not self.live_last_tick:
-                now = int(datetime.datetime.now().strftime('%s'))
-                if now - self.went_live > 600:
-                    self.went_live = int(datetime.datetime.strptime(live_data[0]['started_at'], "%Y-%m-%dT%H:%M:%SZ").strftime('%s'))
-                    self.live_last_tick = True
-                    game_data = await self.get_game_data(live_data[0]['game_id'])
-                    self.embed.add_field(name='Title', inline=False, value=live_data[0]['title'])
-                    self.embed.add_field(name='Category', inline=False, value=game_data['name'])
-                    self.embed.set_image(url=game_data['art'])
-                    channel = discord_client.get_channel(int(self.channel))
-                    await channel.send(content=self.message, embed=self.embed)
-                    self.embed.clear_fields()
-                else:
-                    self.live_last_tick = True
-            else:
-                self.live_last_tick = True
-        else:
-            self.live_last_tick = False
-    async def is_live(self):
-        async with aiohttp.ClientSession() as session:
-            async with session.get(f"{streamer_api}{self.streamer}", headers=headers) as r:
-                if r.status == 200:
-                    live_data = await r.json()
-                    if len(live_data['data']) > 0:
-                       return live_data['data']
-                    else:
-                        return None
-                else:
-                    return None
-    async def get_game_data(self, game_id):
+class NotificationState(ABC):
+    @abstractmethod
+    async def next(self, streamer, live_data):
+        pass
+
+
+class Offline(NotificationState):
+    async def next(self, streamer, live_data):
+        if live_data is not None:
+            return await Pending().next(streamer, live_data)
+        return self
+
+
+class Pending(NotificationState):
+    def __init__(self):
+        self.observed = datetime.datetime.utcnow()
+
+    async def next(self, streamer, live_data):
+        if live_data is None:
+            return Offline()
+
+        now = datetime.datetime.utcnow()
+        elapsed = (now - self.observed).seconds
+        print(f"Elapsed: {elapsed}")
+        if elapsed > streamer['delay']:
+            return await Announcing().next(streamer, live_data)
+        return self
+
+
+class Announcing(NotificationState):
+    @staticmethod
+    async def get_game_data(game_id):
         async with aiohttp.ClientSession() as session:
             async with session.get(f"{game_api}{game_id}", headers=headers) as r:
                 if r.status == 200:
@@ -67,23 +54,97 @@ class Streamer():
                         'art': game_data['data'][0]['box_art_url'].format(width="170", height="226")
                     }
 
+    @staticmethod
+    def build_embed(twitch_name, stream_title, game_name, image_url):
+        embed = discord.Embed(title=f"https://twitch.tv/{twitch_name}", color=discord.Color(0x6441a4))
+        embed.add_field(name='Title', inline=False, value=stream_title)
+        embed.add_field(name='Category', inline=False, value=game_name)
+        embed.set_image(url=image_url)
+        embed.set_footer(text="bot by Woovie#5555 | https://github.com/woovie/twitchlive")
+        embed.set_thumbnail(url="https://assets.help.twitch.tv/Glitch_Purple_RGB.png")
+        return embed
+
+    async def next(self, streamer, live_data):
+        if live_data is None:
+            return Offline()
+
+        game_data = await self.get_game_data(live_data[0]['game_id'])
+        embed = self.build_embed(streamer['twitch_name'], live_data[0]['title'], game_data['name'], game_data['art'])
+        channel = discord_client.get_channel(int(streamer['announce_channel']))
+        await channel.send(content=streamer['message'], embed=embed)
+        return await Announced().next(streamer, live_data)
+
+
+class Announced(NotificationState):
+    async def next(self, streamer, live_data):
+        if live_data is None:
+            return Offline()
+        return self
+
+
+class DiscordClient(discord.Client):
+    async def on_ready(self):
+        print(f"Logged in as {self.user}")
+
+
+class Notifier:
+    def __init__(self, streamer):
+        self.streamer = streamer
+        self.state = Offline()
+        self.job = None
+
+    def start(self):
+        if self.job is None:
+            self.job = sched.add_job(self.process_live_check, 'interval', seconds=self.streamer['frequency'])
+
+    def stop(self):
+        if self.job is not None:
+            self.job.remove()
+            self.job = None
+            self.state = Offline()
+
+    async def process_live_check(self):
+        live_data = await self.is_live()
+        current_state = self.state
+        self.state = await self.state.next(self.streamer, live_data)
+
+    async def is_live(self):
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"{streamer_api}{self.streamer['twitch_name']}", headers=headers) as r:
+                if r.status == 200:
+                    live_data = await r.json()
+                    if len(live_data['data']) > 0:
+                        return live_data['data']
+                    else:
+                        return None
+                else:
+                    return None
+
+
 def add_streamer(twitch_username, message, channel):
     if '@here' in message or '@everyone' in message:
         return None
     else:
-        sched.pause()
+        if twitch_username in notifiers:
+            notifiers[twitch_username].stop()
+
         streamer = {
             "twitch_name": twitch_username,
-            "frequency": 5,
+            "frequency": 10,
+            "delay": 10,
             "active": True,
             "message": message,
             "announce_channel": channel
         }
-        Streamer(streamer['twitch_name'], streamer['frequency'], streamer['message'], streamer['announce_channel'])
         with open(streamer_path, 'w') as f:
             streamers = json.load(f)
             streamers.append(streamer)
             f.write(json.dump(streamers))
+
+        to_add = Notifier(streamer)
+        notifiers[twitch_username] = to_add
+        to_add.start()
+
 
 def set_announce_channel(server, channel):
     if not server in config:
@@ -92,14 +153,21 @@ def set_announce_channel(server, channel):
     with open(config_path, 'w') as configfile:
         config.write(configfile)
 
+
 discord_client = DiscordClient()
 sched = AsyncIOScheduler()
+notifiers = {}
+
 with open(streamer_path, 'r') as f:
-    streamers = json.load(f)
-    for streamer in streamers:
-        print(f"Reading streamer{streamer['twitch_name']}...")
-        if streamer['active']:
-                print(f"Adding streamer {streamer['twitch_name']}")
-                streamer_obj = Streamer(streamer['twitch_name'], streamer['frequency'], streamer['message'], streamer['announce_channel'])
+    streamerJson = json.load(f)
+    for json in streamerJson:
+        notifiers[json['twitch_name']] = Notifier(json)
+
+print(f"Found configurations for streamers: {list(notifiers)}")
+for name, notifier in notifiers.items():
+    if notifier.streamer['active']:
+        print(f"Starting notifier for streamer {name}...")
+        notifier.start()
+
 sched.start()
 discord_client.run(config['discord']['token'])

--- a/streamers.example.json
+++ b/streamers.example.json
@@ -3,6 +3,7 @@
     {
         "twitch_name": "super_cool_streamer",
         "frequency": 5,
+        "delay": 5,
         "active": true,
         "message": "hey I'm live @here",
         "announce_channel": 105420838487990272


### PR DESCRIPTION
Had some ideas about what was causing the multiple fields being added, and ended up messing around a bit more than I thought I would.

This changeset started out to do a few things:
* Replaces use of `strftime('%s')` since that's not Posix compliant
* Fix an issue where you were `now - self.went_live > 600` when `self.went_live` was always zero on first run
* Fix an issue where you were pausing the scheduler when updating the on-disk json file, but never resuming it

And then I got carried away:
* Introduces a state chain mechanism to make help dealing with the transition between various stages easier to track
* Added a `delay` field to the `streamers.json` definition to define how long to wait from first seeing them live to announcing in the channel
* Attempted to add some `update` functionality to the list of notifications, that way you don't end up with multiple notifications for the same streamer when adding them via commands (Note: the `streamers.json` might want to be updated to make `announce_channel` a list instead of a single value, that way you don't have to multiply the number of poling requests made if you want to announce in two channels for one twitch user)